### PR TITLE
Update renderer.php 

### DIFF
--- a/classes/output/multichoice/renderer.php
+++ b/classes/output/multichoice/renderer.php
@@ -49,6 +49,7 @@ class qtype_multichoice_override_renderer extends \qtype_multichoice_single_rend
      * @return string
      */
     public function formulation_and_controls(question_attempt $qa, question_display_options $options) {
+        global $DB;
         $question = $qa->get_question();
         $response = $question->get_response($qa);
 
@@ -57,6 +58,14 @@ class qtype_multichoice_override_renderer extends \qtype_multichoice_single_rend
                 'type' => $this->get_input_type(),
                 'name' => $inputname,
         );
+        
+        // we overwrite the type if it is not a single multichoice
+        $questionid = $qa->get_question_id();
+        $specific_type = $DB->get_record('qtype_multichoice_options', ['questionid' => $questionid], 'single', MUST_EXIST);
+        if ($specific_type->single == 0){
+            $inputattributes['type'] = 'checkbox';
+        }
+        
 
         if ($options->readonly) {
             $inputattributes['disabled'] = 'disabled';


### PR DESCRIPTION
Fixing 
https://github.com/moodleou/moodle-quiz_answersheets/issues/31

`mod/quiz/report/answersheets/classes/output/multichoice/renderer.php`    inherits from   `qtype_multichoice_single_renderer` 

but you can overwrite the question type if you insert following lines, right after you get the input attributes.
I explicitly commented the lines of code only here.

```
        global $DB;
        // every question has its unique id
        $questionid = $qa->get_question_id();
        //   Because we have a multicoice question, it is either a single and therefore is rendered originally as radio-button
        //   or it is a not a single, because more than one answer is possible, then it is originally rendered as checkbox.
        //   the type can be retrieved from the database table  qtype_multichoice_options
        $specific_type = $DB->get_record('qtype_multichoice_options', ['questionid' => $questionid], 'single', MUST_EXIST);
        if ($specific_type->single == 0){
            $inputattributes['type'] = 'checkbox';
        }

```
 This fix renders a radio button if it is a single multichoice and renders a checkbox if it is **not** a single multichoice.
