### PR TITLE
issue #35: move classes around to fix missing file error

### DIFF
--- a/classes/local/renderer/combined/renderer.php
+++ b/classes/local/renderer/combined/renderer.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace quiz_answersheets\output\combined;
+namespace quiz_answersheets\local\renderer\combined;
 
 use coding_exception;
 use html_writer;

--- a/classes/local/renderer/gapselect/renderer.php
+++ b/classes/local/renderer/gapselect/renderer.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace quiz_answersheets\output\gapselect;
+namespace quiz_answersheets\local\renderer\gapselect;
 
 use html_writer;
 use question_attempt;

--- a/classes/local/renderer/match/renderer.php
+++ b/classes/local/renderer/match/renderer.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace quiz_answersheets\output\match;
+namespace quiz_answersheets\local\renderer\match;
 
 use html_writer;
 use question_attempt;

--- a/classes/local/renderer/multichoice/renderer.php
+++ b/classes/local/renderer/multichoice/renderer.php
@@ -15,14 +15,14 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * The override qtype_oumultiresponse_renderer for the quiz_answersheets module.
+ * The override qtype_multichoice_renderer for the quiz_answersheets module.
  *
  * @package   quiz_answersheets
  * @copyright 2020 The Open University
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace quiz_answersheets\output\oumultiresponse;
+namespace quiz_answersheets\local\renderer\multichoice;
 
 use html_writer;
 use question_attempt;
@@ -31,18 +31,18 @@ use question_state;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/question/type/oumultiresponse/renderer.php');
+require_once($CFG->dirroot . '/question/type/multichoice/renderer.php');
 
 /**
- * The override qtype_oumultiresponse_renderer for the quiz_answersheets module.
+ * The override qtype_multichoice_renderer for the quiz_answersheets module.
  *
  * @copyright  2020 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_oumultiresponse_override_renderer extends \qtype_oumultiresponse_renderer {
+class qtype_multichoice_override_renderer extends \qtype_multichoice_single_renderer {
 
     /**
-     * The code was copied from question/type/oumultiresponse/renderer.php, with modifications.
+     * The code was copied from question/type/multichoice/renderer.php, with modifications.
      *
      * @param question_attempt $qa
      * @param question_display_options $options
@@ -71,17 +71,12 @@ class qtype_oumultiresponse_override_renderer extends \qtype_oumultiresponse_ren
             $inputattributes['name'] = $this->get_input_name($qa, $value);
             $inputattributes['value'] = $this->get_input_value($value);
             $inputattributes['id'] = $this->get_input_id($qa, $value);
-            // Modification starts.
-            /* Comment out core code.
             $isselected = $question->is_choice_selected($response, $value);
             if ($isselected) {
                 $inputattributes['checked'] = 'checked';
             } else {
                 unset($inputattributes['checked']);
             }
-            */
-            $inputattributes['checked'] = 'checked';
-            // Modification ends.
             $hidden = '';
             if (!$options->readonly && $this->get_input_type() == 'checkbox') {
                 $hidden = html_writer::empty_tag('input', array(

--- a/classes/local/renderer/oumultiresponse/renderer.php
+++ b/classes/local/renderer/oumultiresponse/renderer.php
@@ -15,14 +15,14 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * The override qtype_multichoice_renderer for the quiz_answersheets module.
+ * The override qtype_oumultiresponse_renderer for the quiz_answersheets module.
  *
  * @package   quiz_answersheets
  * @copyright 2020 The Open University
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace quiz_answersheets\output\multichoice;
+namespace quiz_answersheets\local\renderer\oumultiresponse;
 
 use html_writer;
 use question_attempt;
@@ -31,18 +31,18 @@ use question_state;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/question/type/multichoice/renderer.php');
+require_once($CFG->dirroot . '/question/type/oumultiresponse/renderer.php');
 
 /**
- * The override qtype_multichoice_renderer for the quiz_answersheets module.
+ * The override qtype_oumultiresponse_renderer for the quiz_answersheets module.
  *
  * @copyright  2020 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_multichoice_override_renderer extends \qtype_multichoice_single_renderer {
+class qtype_oumultiresponse_override_renderer extends \qtype_oumultiresponse_renderer {
 
     /**
-     * The code was copied from question/type/multichoice/renderer.php, with modifications.
+     * The code was copied from question/type/oumultiresponse/renderer.php, with modifications.
      *
      * @param question_attempt $qa
      * @param question_display_options $options
@@ -71,12 +71,17 @@ class qtype_multichoice_override_renderer extends \qtype_multichoice_single_rend
             $inputattributes['name'] = $this->get_input_name($qa, $value);
             $inputattributes['value'] = $this->get_input_value($value);
             $inputattributes['id'] = $this->get_input_id($qa, $value);
+            // Modification starts.
+            /* Comment out core code.
             $isselected = $question->is_choice_selected($response, $value);
             if ($isselected) {
                 $inputattributes['checked'] = 'checked';
             } else {
                 unset($inputattributes['checked']);
             }
+            */
+            $inputattributes['checked'] = 'checked';
+            // Modification ends.
             $hidden = '';
             if (!$options->readonly && $this->get_input_type() == 'checkbox') {
                 $hidden = html_writer::empty_tag('input', array(

--- a/classes/local/renderer/pmatch/renderer.php
+++ b/classes/local/renderer/pmatch/renderer.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace quiz_answersheets\output\pmatch;
+namespace quiz_answersheets\local\renderer\pmatch;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/classes/local/renderer/randomsamatch/renderer.php
+++ b/classes/local/renderer/randomsamatch/renderer.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace quiz_answersheets\output\randomsamatch;
+namespace quiz_answersheets\local\renderer\randomsamatch;
 
 use quiz_answersheets\output\match\qtype_match_override_renderer;
 

--- a/classes/local/renderer/recordrtc/renderer.php
+++ b/classes/local/renderer/recordrtc/renderer.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace quiz_answersheets\output\recordrtc;
+namespace quiz_answersheets\local\renderer\recordrtc;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/classes/local/renderer/stack/renderer.php
+++ b/classes/local/renderer/stack/renderer.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace quiz_answersheets\output\stack;
+namespace quiz_answersheets\local\renderer\stack;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/classes/local/renderer/truefalse/renderer.php
+++ b/classes/local/renderer/truefalse/renderer.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace quiz_answersheets\output\truefalse;
+namespace quiz_answersheets\local\renderer\truefalse;
 
 use html_writer;
 use question_attempt;

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -410,11 +410,14 @@ class utils {
         global $CFG;
 
         $qtypename = $qa->get_question()->get_type_name();
-        $requirefile = $CFG->dirroot . '/mod/quiz/report/answersheets/classes/output/' . $qtypename . '/renderer.php';
+        $requirefile = $CFG->dirroot . '/mod/quiz/report/answersheets/classes/local/renderer/' . $qtypename . '/renderer.php';
         if (file_exists($requirefile)) {
             // Override supported question found.
             require_once($requirefile);
-            $classpath = sprintf('quiz_answersheets\output\\' . $qtypename . '\%s', 'qtype_' . $qtypename . '_override_renderer');
+            $classpath = sprintf(
+                'quiz_answersheets\local\renderer\\' . $qtypename . '\%s',
+                'qtype_' . $qtypename . '_override_renderer'
+            );
             return new $classpath($page, null);
         }
 


### PR DESCRIPTION
As part of this patch we are moving renderer classes out of output folder to local/renderer to make core component tests happy in case if not all supported question types are installed.

Technically all renderers could be in any folder as in utils::get_question_renderer method we require a renderer file regardless. So no autoloading is used anyway.

Core tests with that patch:

root@c7387df7e44d:/var/www/moodl41# vendor/bin/phpunit lib/tests/component_test.php
Moodle 4.1.1+ (Build: 20230224), ab1ad2ddfc1cf279deddfd7165502067cf63e392
Php: 7.4.30, mysqli: 5.7.39, OS: Linux 5.15.0-58-generic x86_64
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

................................................................. 65 / 73 ( 89%)
........                                                          73 / 73 (100%)

Time: 00:02.252, Memory: 95.50 MB

OK (73 tests, 4199 assertions)
