### PR TITLE
Issue #35: Workaround when the class does not exist

### DIFF
--- a/classes/output/combined/renderer.php
+++ b/classes/output/combined/renderer.php
@@ -36,9 +36,27 @@ use quiz_answersheets\utils;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/question/type/combined/renderer.php');
-require_once($CFG->dirroot . '/question/type/combined/combinable/gapselect/renderer.php');
-require_once($CFG->dirroot . '/question/type/oumultiresponse/combinable/renderer.php');
+// Work-around when the class does not exist.
+if (class_exists('\qtype_combined_renderer')) {
+    class_alias('\qtype_combined_renderer', '\qtype_combined_renderer_alias');
+    require_once($CFG->dirroot . '/question/type/combined/renderer.php');
+} else {
+    class_alias('\qtype_renderer', '\qtype_combined_renderer_alias');
+}
+
+if (class_exists('\qtype_oumultiresponse_embedded_renderer')) {
+    class_alias('\qtype_oumultiresponse_embedded_renderer', '\qtype_oumultiresponse_embedded_renderer_alias');
+    require_once($CFG->dirroot . '/question/type/oumultiresponse/combinable/renderer.php');
+} else {
+    class_alias('\qtype_renderer', '\qtype_oumultiresponse_embedded_renderer_alias');
+}
+
+if (class_exists('\qtype_combined_gapselect_embedded_renderer')) {
+    class_alias('\qtype_combined_gapselect_embedded_renderer', '\qtype_combined_gapselect_embedded_renderer_alias');
+    require_once($CFG->dirroot . '/question/type/combined/combinable/gapselect/renderer.php');
+} else {
+    class_alias('\qtype_renderer', '\qtype_combined_gapselect_embedded_renderer_alias');
+}
 
 /**
  * The override qtype_combined_renderer for the quiz_answersheets module.
@@ -46,7 +64,7 @@ require_once($CFG->dirroot . '/question/type/oumultiresponse/combinable/renderer
  * @copyright  2020 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_combined_override_renderer extends \qtype_combined_renderer {
+class qtype_combined_override_renderer extends \qtype_combined_renderer_alias {
 
     /**
      * The code was copied from question/type/combined/renderer.php, with modifications.
@@ -158,7 +176,7 @@ class qtype_combined_override_renderer extends \qtype_combined_renderer {
  *
  * @package quiz_answersheets\output\combined
  */
-class qtype_oumultiresponse_embedded_override_renderer extends \qtype_oumultiresponse_embedded_renderer {
+class qtype_oumultiresponse_embedded_override_renderer extends \qtype_oumultiresponse_embedded_renderer_alias {
 
     /**
      * The code was copied from question/type/oumultiresponse/combinable/renderer.php, with modifications.
@@ -247,7 +265,7 @@ class qtype_oumultiresponse_embedded_override_renderer extends \qtype_oumultires
  *
  * @package quiz_answersheets\output\combined
  */
-class qtype_combined_gapselect_embedded_override_renderer extends \qtype_combined_gapselect_embedded_renderer {
+class qtype_combined_gapselect_embedded_override_renderer extends \qtype_combined_gapselect_embedded_renderer_alias {
 
     /**
      * Render the sub question.

--- a/classes/output/oumatrix/renderer.php
+++ b/classes/output/oumatrix/renderer.php
@@ -31,7 +31,13 @@ use question_state;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/question/type/oumatrix/renderer.php');
+// Work-around when the class does not exist.
+if (class_exists('\qtype_oumatrix_single_renderer')) {
+    class_alias('\qtype_oumatrix_single_renderer', '\qtype_oumatrix_single_renderer_alias');
+    require_once($CFG->dirroot . '/question/type/oumatrix/renderer.php');
+} else {
+    class_alias('\qtype_renderer', '\qtype_oumatrix_single_renderer_alias');
+}
 
 /**
  * The override qtype_oumatrix_renderer for the quiz_answersheets module.
@@ -39,7 +45,7 @@ require_once($CFG->dirroot . '/question/type/oumatrix/renderer.php');
  * @copyright  2023 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_oumatrix_override_renderer extends \qtype_oumatrix_single_renderer {
+class qtype_oumatrix_override_renderer extends \qtype_oumatrix_single_renderer_alias {
 
     /**
      * The code was copied from question/type/oumatrix/renderer.php, with modifications.

--- a/classes/output/oumultiresponse/renderer.php
+++ b/classes/output/oumultiresponse/renderer.php
@@ -31,7 +31,13 @@ use question_state;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/question/type/oumultiresponse/renderer.php');
+// Work-around when the class does not exist.
+if (class_exists('\qtype_oumultiresponse_renderer')) {
+    class_alias('\qtype_oumultiresponse_renderer', '\qtype_oumultiresponse_renderer_alias');
+    require_once($CFG->dirroot . '/question/type/oumultiresponse/renderer.php');
+} else {
+    class_alias('\qtype_renderer', '\qtype_oumultiresponse_renderer_alias');
+}
 
 /**
  * The override qtype_oumultiresponse_renderer for the quiz_answersheets module.
@@ -39,7 +45,7 @@ require_once($CFG->dirroot . '/question/type/oumultiresponse/renderer.php');
  * @copyright  2020 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_oumultiresponse_override_renderer extends \qtype_oumultiresponse_renderer {
+class qtype_oumultiresponse_override_renderer extends \qtype_oumultiresponse_renderer_alias {
 
     /**
      * The code was copied from question/type/oumultiresponse/renderer.php, with modifications.

--- a/classes/output/pmatch/renderer.php
+++ b/classes/output/pmatch/renderer.php
@@ -29,7 +29,13 @@ defined('MOODLE_INTERNAL') || die();
 use qtype_pmatch_question;
 use question_display_options;
 
-require_once($CFG->dirroot . '/question/type/pmatch/renderer.php');
+// Work-around when the class does not exist.
+if (class_exists('\qtype_pmatch_renderer')) {
+    class_alias('\qtype_pmatch_renderer', '\qtype_pmatch_renderer_alias');
+    require_once($CFG->dirroot . '/question/type/pmatch/renderer.php');
+} else {
+    class_alias('\qtype_renderer', '\qtype_pmatch_renderer_alias');
+}
 
 /**
  * The override qtype_pmatch_renderer for the quiz_answersheets module.
@@ -37,7 +43,7 @@ require_once($CFG->dirroot . '/question/type/pmatch/renderer.php');
  * @copyright  2020 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_pmatch_override_renderer extends \qtype_pmatch_renderer {
+class qtype_pmatch_override_renderer extends \qtype_pmatch_renderer_alias {
 
     /**
      * The code was copied from question/type/pmatch/renderer.php, with modifications.

--- a/classes/output/recordrtc/renderer.php
+++ b/classes/output/recordrtc/renderer.php
@@ -32,7 +32,13 @@ use html_writer;
 use question_attempt;
 use question_display_options;
 
-require_once($CFG->dirroot . '/question/type/recordrtc/renderer.php');
+// Work-around when the class does not exist.
+if (class_exists('\qtype_recordrtc_renderer')) {
+    class_alias('\qtype_recordrtc_renderer', '\qtype_recordrtc_renderer_alias');
+    require_once($CFG->dirroot . '/question/type/recordrtc/renderer.php');
+} else {
+    class_alias('\qtype_renderer', '\qtype_recordrtc_renderer_alias');
+}
 
 /**
  * The override qtype_recordrtc_renderer for the quiz_answersheets module.
@@ -40,7 +46,7 @@ require_once($CFG->dirroot . '/question/type/recordrtc/renderer.php');
  * @copyright  2020 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_recordrtc_override_renderer extends \qtype_recordrtc_renderer {
+class qtype_recordrtc_override_renderer extends \qtype_recordrtc_renderer_alias {
 
     /**
      * The code was copied from question/type/recordrtc/renderer.php, with modifications.

--- a/classes/output/stack/renderer.php
+++ b/classes/output/stack/renderer.php
@@ -36,7 +36,13 @@ use quiz_answersheets\utils;
 use stack_maths;
 use stack_utils;
 
-require_once($CFG->dirroot . '/question/type/stack/renderer.php');
+// Work-around when the class does not exist.
+if (class_exists('\qtype_stack_renderer')) {
+    class_alias('\qtype_stack_renderer', '\qtype_stack_renderer_alias');
+    require_once($CFG->dirroot . '/question/type/stack/renderer.php');
+} else {
+    class_alias('\qtype_renderer', '\qtype_stack_renderer_alias');
+}
 
 /**
  * The override qtype_stack_renderer for the quiz_answersheets module.
@@ -44,7 +50,7 @@ require_once($CFG->dirroot . '/question/type/stack/renderer.php');
  * @copyright  2020 The Open University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_stack_override_renderer extends \qtype_stack_renderer {
+class qtype_stack_override_renderer extends \qtype_stack_renderer_alias {
 
     /**
      * The code was copied from question/type/stack/renderer.php, with modifications.


### PR DESCRIPTION
This is a workaround to avoid the phpunit issue.

Basically check the class and using alias for the class definition.

https://moodledev.io/docs/4.2/devupdate#developer-tip---handling-changes-to-base-class-names-while-supporting-multiple-moodle-versions

After this patch, the phpunit test for `lib/tests/component_test.php` is working ok.